### PR TITLE
Fix: Removed unnecessary path in NOTE_B1 define

### DIFF
--- a/ESP_Music.h
+++ b/ESP_Music.h
@@ -15,7 +15,7 @@
 #define NOTE_GS1 52
 #define NOTE_A1  55
 #define NOTE_AS1 58
-#define NOTE_B1  62c:\Users\ertug\OneDrive\Belgeler\Arduino\ESP_Music\ESP_Music.h
+#define NOTE_B1  62
 #define NOTE_C2  65
 #define NOTE_CS2 69
 #define NOTE_D2  73


### PR DESCRIPTION
## Sourcery Tarafından Özet

Hata Düzeltmeleri:
- ESP_Music.h dosyasındaki NOTE_B1 tanımlamasına eklenmiş gereksiz dosya yolunu kaldır.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Remove unnecessary file path appended to the NOTE_B1 define in ESP_Music.h

</details>